### PR TITLE
fix cdn link in korean README.md

### DIFF
--- a/lang/korean/README.md
+++ b/lang/korean/README.md
@@ -112,7 +112,7 @@ npm install fullpage.js
 Using Webpack, Browserify or Require.js? Check <a href="https://github.com/alvarotrigo/fullPage.js/wiki/Use-module-loaders-for-fullPage.js">how to use fullPage.js with module loaders</a>.
 
 ### CDN 사용 가능
-필요한 파일을 불러오실 때 CDN이 더 편하시다면 fullPage.js를 CDNJS 양식(https://cdnjs.com/libraries/fullPage.js)으로도 사용하실 수 있습니다.
+필요한 파일을 불러오실 때 CDN이 더 편하시다면 fullPage.js를 CDNJS 양식(<https://cdnjs.com/libraries/fullPage.js>)으로도 사용하실 수 있습니다.
 
 ### 필요한 HTML 구조
 HTML 코드의 첫번째 줄에 필수 [HTML DOCTYPE 표기](http://www.corelangs.com/html/introduction/doctype.html)를 넣어주세요. 넣지 않으시면 구역의 높이가 깨질 수 있습니다. 제시된 사례에서는 HTML 5 doctype `<!DOCTYPE html>`을 씁니다.


### PR DESCRIPTION
fix cdn link url

1. Make sure to commit it to the `dev` branch!
2. Read https://github.com/alvarotrigo/fullPage.js/wiki/Contributing-to-fullpage.js
